### PR TITLE
Add Infra Audit to Unified View in web UI 

### DIFF
--- a/pattern/info-assurance-controls/ux.sql.ts
+++ b/pattern/info-assurance-controls/ux.sql.ts
@@ -47,11 +47,11 @@ export class InfoAssuranceControlsSqlPages extends spn.TypicalSqlPageNotebook {
   @icNav({
     caption: "Information Assurance Controls",
     description:
-      `The Infra Controls project is designed to manage and implement controls specific
-to various audit requirements, such as CC1001, CC1002, and others. This project
-provides a platform for defining, applying, and tracking the effectiveness of
-these controls, ensuring that your organization meets the necessary standards
-for audit compliance.`,
+      `The Infra Controls is designed to manage and implement controls specific
+      to various audit requirements, such as CC1001, CC1002, and others. This project
+      provides a platform for defining, applying, and tracking the effectiveness of
+      these controls, ensuring that your organization meets the necessary standards
+      for audit compliance.`,
     siblingOrder: 2,
   })
   "opsfolio/info/control/control_dashboard.sql"() {

--- a/pattern/info-assurance-policies/ux.sql.ts
+++ b/pattern/info-assurance-policies/ux.sql.ts
@@ -47,10 +47,10 @@ export class InfoAssurancePolicySqlPages extends spn.TypicalSqlPageNotebook {
   @ipNav({
     caption: "Information Assurance Policies",
     description:
-      `The Infra Policies project is designed to display and create views for policies
-specific to tenants within the Opsfolio platform. These policies are ingested
-from Markdown (.md) or Markdown with JSX (.mdx) files, originating from
-Opsfolio, and are stored in the uniform_resource table.`,
+      `The Infra Policies is designed to display and create views for policies
+        specific to tenants within the Opsfolio platform. These policies are ingested
+        from Markdown (.md) or Markdown with JSX (.mdx) files, originating from
+        Opsfolio, and are stored in the uniform_resource table.`,
     siblingOrder: 2,
   })
   "opsfolio/info/policy/policy_dashboard.sql"() {

--- a/pattern/infra-assurance/stateless-ia.surveilr.sql
+++ b/pattern/infra-assurance/stateless-ia.surveilr.sql
@@ -24,10 +24,10 @@ CREATE VIEW uniform_resource_summary AS
     FROM
         uniform_resource;
 
-DROP VIEW IF EXISTS boundery;
-CREATE VIEW boundery AS
+DROP VIEW IF EXISTS boundary;
+CREATE VIEW boundary AS
    SELECT 
-    json_extract(inner.value, '$.b:DisplayName') AS displayName,
+    json_extract(outer.value, '$.a:Value.Properties.a:anyType[0].b:DisplayName') AS displayName,
     json_extract(inner.value, '$.b:Value.#text') AS name,
     json_extract(outer.value, '$.a:Value.@i:type') as type
 FROM 

--- a/pattern/infra-assurance/ux.sql.ts
+++ b/pattern/infra-assurance/ux.sql.ts
@@ -47,7 +47,7 @@ export class InfraAssuranceSqlPages extends spn.TypicalSqlPageNotebook {
   @iaNav({
     caption: "Infrastructure Assurance",
     description:
-      `The Infra Assurance project focuses on managing and overseeing assets and
+      `The Infra Assurance focuses on managing and overseeing assets and
 portfolios within an organization. This project provides tools and processes to
 ensure the integrity, availability, and effectiveness of assets and portfolios,
 supporting comprehensive assurance and compliance efforts.`,
@@ -58,7 +58,7 @@ supporting comprehensive assurance and compliance efforts.`,
         select
     'card'             as component,
     3                 as columns;
-    select name as title FROM boundery;`;
+    select name as title FROM boundary;`;
   }
 }
 

--- a/pattern/infra-audit/stateless-ia.surveilr.sql
+++ b/pattern/infra-audit/stateless-ia.surveilr.sql
@@ -14,8 +14,8 @@
 -- Provides a count of total rows, valid JSON rows, invalid JSON rows,
 -- and potential CCDA v4 candidates and bundles based on JSON structure.
 
-
-CREATE VIEW IF NOT EXISTS tenant_based_control_regime AS SELECT tcr.control_regime_id,
+DROP VIEW IF EXISTS tenant_based_control_regime;
+CREATE VIEW tenant_based_control_regime AS SELECT tcr.control_regime_id,
       tcr.tenant_id,
       cr.name,
       cr.parent_id,
@@ -28,7 +28,23 @@ FROM tenant_control_regime tcr
 JOIN control_regime cr on cr.control_regime_id = tcr.control_regime_id;
 
 
-CREATE VIEW IF NOT EXISTS audit_session_list AS SELECT 
+DROP VIEW IF EXISTS audit_session_control;
+CREATE VIEW audit_session_control
+      AS
+        SELECT c.control_group_id,
+          c.control_id,
+          c.question,
+          c.display_order,
+          c.control_code,
+          ac.audit_control_id,
+          ac.control_audit_status AS status,
+          ac.audit_session_id
+        FROM audit_control ac
+        JOIN control c ON c.control_id = ac.control_id;
+
+
+DROP VIEW IF EXISTS audit_session_list;
+CREATE VIEW audit_session_list AS SELECT 
       a.audit_session_id,
       a.control_regime_id as audit_type_id, 
       a.title, 
@@ -70,7 +86,926 @@ CREATE VIEW IF NOT EXISTS audit_session_list AS SELECT
       p.party_name;
 
 
-CREATE VIEW IF NOT EXISTS audit_session_control_status AS 
+DROP VIEW IF EXISTS query_result;
+CREATE VIEW IF NOT EXISTS query_result AS
+          WITH RECURSIVE extract_blocks AS (
+            SELECT
+              uniform_resource_id,
+              uri,
+              device_id,
+              content_digest,
+              nature,
+              size_bytes,
+              last_modified_at,
+              created_at,
+              updated_at,
+              substr(content, instr(content, '<QueryResult'), instr(content || '</QueryResult>', '</QueryResult>') - instr(content, '<QueryResult') + length('</QueryResult>')) AS query_content,
+              substr(content, instr(content, '</QueryResult>') + length('</QueryResult>')) AS remaining_content
+            FROM
+              uniform_resource
+            WHERE
+              content LIKE '%<QueryResult%' AND nature='mdx'
+            UNION ALL
+            SELECT
+              uniform_resource_id,
+              uri,
+              device_id,
+              content_digest,
+              nature,
+              size_bytes,
+              last_modified_at,
+              created_at,
+              updated_at,
+              substr(remaining_content, instr(remaining_content, '<QueryResult'), instr(remaining_content || '</QueryResult>', '</QueryResult>') - instr(remaining_content, '<QueryResult') + length('</QueryResult>')) AS query_content,
+              substr(remaining_content, instr(remaining_content, '</QueryResult>') + length('</QueryResult>')) AS remaining_content
+          FROM
+              extract_blocks
+            WHERE
+              remaining_content LIKE '%<QueryResult%' AND nature='mdx'
+        ),
+        latest_entries AS (
+            SELECT
+              uri,
+              MAX(last_modified_at) AS latest_last_modified_at
+            FROM
+              uniform_resource
+            WHERE
+              nature = 'mdx'
+            GROUP BY
+              uri
+        )
+        SELECT
+          eb.uniform_resource_id,
+          eb.uri,
+          eb.device_id,
+          eb.content_digest,
+          eb.nature,
+          eb.size_bytes,
+          eb.last_modified_at,
+          eb.created_at,
+          eb.updated_at,
+          eb.query_content
+        FROM
+          extract_blocks eb
+        JOIN
+          latest_entries le
+        ON
+          eb.uri = le.uri AND eb.last_modified_at = le.latest_last_modified_at;
+
+
+DROP VIEW IF EXISTS audit_session_info;
+CREATE VIEW audit_session_info AS
+      SELECT a.audit_session_id,
+      a.title,
+      a.due_date,
+      a.created_at,
+      a.updated_at,
+      a.tenant_id,
+      a.status,
+      a.deleted_at,
+      a.deleted_by,
+      p1.party_name AS contact_person,
+      p2.party_name AS tenant_name,
+      crg.control_regime_id as audit_type_id,
+      crg.name AS audit_type,
+      cr2.name AS control_regime_name,
+      cr2.control_regime_id
+      FROM audit_session a
+      JOIN party p1 ON p1.party_id = a.contact_person
+      JOIN control_regime crg ON crg.control_regime_id = a.control_regime_id
+      JOIN control_regime cr2 on cr2.control_regime_id = crg.parent_id
+      JOIN party p2 on p2.party_id = a.tenant_id;
+
+
+DROP VIEW IF EXISTS evidence_query_result;
+CREATE VIEW evidence_query_result AS
+        WITH extracted_data AS (
+          SELECT
+            uniform_resource_id,
+            uri,
+            device_id,
+            content_digest,
+            nature,
+            size_bytes,
+            last_modified_at,
+            created_at,
+            updated_at,
+            CASE
+              WHEN INSTR(query_content, 'title="') > 0 THEN
+                SUBSTR(query_content,
+                  INSTR(query_content, 'title="') + LENGTH('title="'),
+                  INSTR(SUBSTR(query_content, INSTR(query_content, 'title="') + LENGTH('title="')), '"') - 1
+                )
+              ELSE NULL
+            END AS title,
+            CASE
+              WHEN INSTR(query_content, 'gridStyle="') > 0 THEN
+                SUBSTR(query_content,
+                  INSTR(query_content, 'gridStyle="') + LENGTH('gridStyle="'),
+                  INSTR(SUBSTR(query_content, INSTR(query_content, 'gridStyle="') + LENGTH('gridStyle="')), '"') - 1
+                )
+              ELSE NULL
+            END AS grid_style,
+            CASE
+              WHEN INSTR(query_content, 'connection="') > 0 THEN
+                SUBSTR(query_content,
+                  INSTR(query_content, 'connection="') + LENGTH('connection="'),
+                  INSTR(SUBSTR(query_content, INSTR(query_content, 'connection="') + LENGTH('connection="')), '"') - 1
+                )
+              ELSE NULL
+            END AS connection,
+            CASE
+              WHEN INSTR(query_content, 'language="') > 0 THEN
+                SUBSTR(query_content,
+                  INSTR(query_content, 'language="') + LENGTH('language="'),
+                  INSTR(SUBSTR(query_content, INSTR(query_content, 'language="') + LENGTH('language="')), '"') - 1
+                )
+              ELSE NULL
+            END AS language,
+            CASE
+              WHEN INSTR(query_content, '{\`') > 0 THEN
+                SUBSTR(query_content,
+                    INSTR(query_content, '{\`') + LENGTH('{\`'),
+                    INSTR(SUBSTR(query_content, INSTR(query_content, '{\`') + LENGTH('{\`')), '\`}') - LENGTH('\`') - 1
+                )
+              ELSE NULL
+            END AS query_content,
+            CASE
+              WHEN INSTR(query_content, 'satisfies="') > 0 THEN
+                SUBSTR(query_content,
+                  INSTR(query_content, 'satisfies="') + LENGTH('satisfies="'),
+                  INSTR(SUBSTR(query_content, INSTR(query_content, 'satisfies="') + LENGTH('satisfies="')), '"') - 1
+                )
+              ELSE NULL
+            END AS satisfies
+          FROM query_result
+        ),
+        split_satisfies AS (
+          SELECT
+            uniform_resource_id,
+            uri,
+            device_id,
+            content_digest,
+            nature,
+            size_bytes,
+            last_modified_at,
+            created_at,
+            updated_at,
+            title,
+            grid_style,
+            connection,
+            language,
+            query_content,
+            TRIM(json_each.value) AS fii,
+            hex(substr(title, 1, 50)) AS short_title_hex,
+            ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title) AS row_num
+          FROM extracted_data,
+          json_each('["' || REPLACE(satisfies, ', ', '","') || '"]')
+        )
+        SELECT
+          uniform_resource_id,
+          uri,
+          device_id,
+          content_digest,
+          nature,
+          size_bytes,
+          last_modified_at,
+          created_at,
+          updated_at,
+          title,
+          grid_style,
+          connection,
+          language,
+          query_content,
+          fii,
+          uniform_resource_id || '-' || short_title_hex || '-0001-' || printf('%04d', row_num) AS evidence_id
+        FROM split_satisfies;
+
+
+DROP VIEW IF EXISTS audit_session_control_group;
+CREATE VIEW audit_session_control_group AS
+      SELECT cg.control_group_id,
+      cg.title AS control_group_name,
+      cg.display_order,
+      a.audit_session_id
+      FROM control_group cg
+      JOIN control c ON c.control_group_id = cg.control_group_id
+      JOIN audit_control ac ON ac.control_id = c.control_id
+      JOIN audit_session a ON a.audit_session_id = ac.audit_session_id
+      GROUP BY cg.control_group_id,
+      cg.title,
+      a.audit_session_id;
+  
+
+DROP VIEW IF EXISTS audit_control_evidence;
+CREATE VIEW audit_control_evidence AS 
+      SELECT
+      acpe.audit_control_id, 
+      acpe.status AS evidence_status,
+      p.policy_id,
+      p.uri,
+      p.title,
+      p.description,
+      p.fii,
+      e.evidence_id,
+      e.evidence,
+      e.title AS evidence_title,
+      e.type AS evidence_type
+    FROM audit_control_policy_evidence acpe
+    JOIN audit_control ac ON ac.audit_control_id = acpe.audit_control_id
+    JOIN control c ON c.control_id = ac.control_id
+    JOIN policy p ON p.policy_id = acpe.policy_id 
+    AND (
+      REPLACE(c.fii, ' ', '') = p.fii
+      OR ',' || REPLACE(c.fii, ' ', '') || ',' LIKE '%,' || p.fii || ',%'
+    )
+    LEFT JOIN evidence e ON e.evidence_id = acpe.evidence_id;
+
+
+DROP VIEW IF EXISTS policy;
+CREATE VIEW policy AS
+        WITH rankedpolicies AS
+          (SELECT u.uniform_resource_id || '-' || u.device_id AS policy_id,
+          u.uniform_resource_id,
+          u.device_id,
+          u.uri,
+          u.content_digest,
+          u.nature,
+          u.size_bytes,
+          u.last_modified_at,
+          Json_extract(u.frontmatter, '$.title') AS title,
+          Json_extract(u.frontmatter, '$.description') AS description,
+          Json_extract(u.frontmatter, '$.publishDate') AS publishDate,
+          Json_extract(u.frontmatter, '$.publishBy') AS publishBy,
+          Json_extract(u.frontmatter, '$.classification') AS classification,
+          Json_extract(u.frontmatter, '$.documentVersion') AS documentVersion,
+          Json_extract(u.frontmatter, '$.documentType') AS documentType,
+          Json_extract(u.frontmatter, '$.approvedBy') AS approvedBy,
+          json_each.value AS fii,
+          u.created_at,
+          u.updated_at,
+          Row_number()
+          OVER (partition BY u.uri, json_each.value ORDER BY u.last_modified_at DESC) AS rn
+          FROM  uniform_resource u,
+          Json_each(Json_extract(u.frontmatter, '$.satisfies'))
+          WHERE  u.nature = 'md' OR u.nature = 'mdx')
+        SELECT policy_id,uniform_resource_id,
+          device_id,
+          uri,
+          content_digest,
+          nature,
+          size_bytes,
+          last_modified_at,
+          title,
+          description,
+          publishdate,
+          publishby,
+          classification,
+          documentversion,
+          documenttype,
+          approvedby,
+          fii,
+          created_at,
+          updated_at
+        FROM rankedpolicies
+        WHERE rn = 1;
+
+
+DROP VIEW IF EXISTS evidence;
+CREATE VIEW evidence AS
+      SELECT eqr.evidence_id,
+        eqr.uniform_resource_id,
+        eqr.uri,
+        eqr.title,
+        eqr.query_content AS evidence,
+        eqr.fii,
+        'Query Result' AS type
+      FROM evidence_query_result eqr
+
+      UNION ALL
+
+      SELECT ea.evidence_id,
+        ea.uniform_resource_id,
+        ea.uri,
+        ea.title,
+        ea.extracted AS evidence,
+        ea.fii,
+        'Anchor Tag' AS type
+      FROM evidence_anchortag ea
+
+      UNION ALL
+
+      SELECT ei.evidence_id,
+        ei.uniform_resource_id,
+        ei.uri,
+        ei.title,
+        ei.extracted AS evidence,
+        ei.fii,
+        'Image Tag' AS type
+      FROM evidence_imagetag ei
+      
+      UNION ALL
+
+      SELECT ec.evidence_id,
+        ec.uniform_resource_id,
+        ec.uri,
+        ec.title,
+        ec.extracted AS evidence,
+        ec.fii,
+        'Evidence Tag' AS type
+      FROM evidence_customtag ec
+      
+      UNION ALL
+
+      SELECT eer.evidence_id,
+        eer.uniform_resource_id,
+        eer.uri,
+        eer.title,
+        eer.extracted AS evidence,
+        eer.fii,
+        'EvidenceResult' AS type
+      FROM evidence_evidenceresult eer;
+
+DROP VIEW IF EXISTS evidence_evidenceresult;
+CREATE VIEW evidence_evidenceresult AS
+  WITH RECURSIVE CTE AS (
+      SELECT 
+          frontmatter->>'title' AS title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          INSTR(content, '<EvidenceResult') AS evidence_result_start,
+          INSTR(content, '</EvidenceResult>') AS evidence_result_end,
+          SUBSTR(content, INSTR(content, '<EvidenceResult'), 
+                INSTR(content, '</EvidenceResult>') - INSTR(content, '<EvidenceResult') + LENGTH('</EvidenceResult>')) AS extracted,
+          SUBSTR(content, INSTR(content, '</EvidenceResult>') + LENGTH('</EvidenceResult>')) AS remaining_content,
+          last_modified_at,
+          created_at,
+          uniform_resource_id
+      FROM
+          uniform_resource
+      WHERE
+          INSTR(content, '<EvidenceResult') > 0  AND (nature='mdx' OR nature='md')
+      UNION ALL
+      SELECT
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          INSTR(remaining_content, '<EvidenceResult') AS evidence_result_start,
+          INSTR(remaining_content, '</EvidenceResult>') AS evidence_result_end,
+          SUBSTR(remaining_content, INSTR(remaining_content, '<EvidenceResult'), 
+                INSTR(remaining_content, '</EvidenceResult>') - INSTR(remaining_content, '<EvidenceResult') + LENGTH('</EvidenceResult>')) AS extracted,
+          SUBSTR(remaining_content, INSTR(remaining_content, '</EvidenceResult>') + LENGTH('</EvidenceResult>')) AS remaining_content,
+          last_modified_at,
+          created_at,
+          uniform_resource_id
+      FROM
+          CTE
+      WHERE
+          INSTR(remaining_content, '<EvidenceResult') > 0 AND INSTR(remaining_content, '</EvidenceResult>') > INSTR(remaining_content, '<EvidenceResult')
+  ),
+  satisfies_split AS (
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          SUBSTR(
+              extracted,
+              INSTR(extracted, 'satisfies="') + LENGTH('satisfies="'),
+              CASE
+                  WHEN INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') > 0 THEN
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') - 1
+                  ELSE
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"') - 1
+              END
+          ) AS satisfies,
+          SUBSTR(
+              extracted,
+              INSTR(extracted, 'satisfies="') + LENGTH('satisfies="') + CASE
+                  WHEN INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') > 0 THEN
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',')
+                  ELSE
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"')
+              END + 1
+          ) AS rest_satisfies
+      FROM
+          CTE
+      WHERE
+          INSTR(extracted, 'satisfies="') > 0
+      UNION ALL
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          TRIM(SUBSTR(rest_satisfies, 1, INSTR(rest_satisfies, ',') - 1)) AS satisfies,
+          SUBSTR(rest_satisfies, INSTR(rest_satisfies, ',') + 1) AS rest_satisfies
+      FROM
+          satisfies_split
+      WHERE
+          INSTR(rest_satisfies, ',') > 0
+      UNION ALL
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          TRIM(rest_satisfies) AS satisfies,
+          NULL AS rest_satisfies
+      FROM
+          satisfies_split
+      WHERE
+          INSTR(rest_satisfies, ',') = 0 AND LENGTH(TRIM(rest_satisfies)) > 0
+  ),
+  latest_entries AS (
+              SELECT
+                uri,
+                MAX(last_modified_at) AS latest_last_modified_at
+              FROM
+                uniform_resource
+              GROUP BY
+                uri
+          )
+  SELECT 
+  ss.uniform_resource_id,
+  ss.uri,
+  ss.nature,
+  ss.device_id,
+  ss.content_digest,
+      ss.title,
+      ss.content,
+      ss.extracted,
+      CASE
+          WHEN INSTR(satisfies, '"') > 0 THEN SUBSTR(satisfies, 1, INSTR(satisfies, '"') - 1)
+          ELSE satisfies
+      END AS fii,
+      ss.last_modified_at,
+      ss.created_at,
+      ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title) AS row_num,
+      uniform_resource_id || '-' || hex(substr(title, 1, 50))|| '-0005-' || printf('%04d', ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title)) AS evidence_id
+  FROM
+    satisfies_split ss
+    JOIN 
+ latest_entries le
+        ON
+          ss.uri = le.uri AND ss.last_modified_at = le.latest_last_modified_at
+  WHERE
+    satisfies IS NOT NULL AND satisfies != '' AND fii LIKE '%FII%' 
+ group by fii
+ ORDER BY
+    ss.title, fii;
+
+
+DROP VIEW IF EXISTS evidence_customtag;
+CREATE VIEW evidence_customtag AS
+      WITH RECURSIVE CTE AS (
+          -- Base case: Initial extraction
+          SELECT
+              uniform_resource_id,
+              uri,
+              nature,
+              device_id,
+              content_digest,
+              frontmatter->>'title' AS title,
+              content,
+              INSTR(content, '<evidence') AS evidence_start,
+              INSTR(SUBSTR(content, INSTR(content, '<evidence')), '/>') AS evidence_end,
+              SUBSTR(content, INSTR(content, '<evidence'), INSTR(SUBSTR(content, INSTR(content, '<evidence')), '/>') + 1) AS extracted,
+              SUBSTR(content, INSTR(content, '<evidence') + INSTR(SUBSTR(content, INSTR(content, '<evidence')), '/>') + 1) AS remaining_content ,
+              last_modified_at,
+              created_at
+          FROM uniform_resource 
+          WHERE INSTR(content, '<evidence') > 0
+          UNION ALL
+          SELECT
+              uniform_resource_id,
+              uri,
+              nature,
+              device_id,
+              content_digest,
+              title,
+              content,
+              INSTR(remaining_content, '<evidence') AS evidence_start,
+              INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<evidence')), '/>') AS evidence_end,
+              SUBSTR(remaining_content, INSTR(remaining_content, '<evidence'), INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<evidence')), '/>') + 1) AS extracted,
+              SUBSTR(remaining_content, INSTR(remaining_content, '<evidence') + INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<evidence')), '/>') + 1) AS remaining_content,
+              last_modified_at,
+              created_at
+          FROM CTE
+          WHERE INSTR(remaining_content, '<evidence') > 0
+      ),
+      ExtractSatisfies AS (
+          SELECT
+              uniform_resource_id,
+              uri,
+              nature,
+              device_id,
+              content_digest,
+              title,
+              content,
+              extracted,
+              
+              -- Extract the value of the satisfies attribute
+              TRIM(SUBSTR(extracted,
+                          INSTR(extracted, 'satisfies="') + LENGTH('satisfies="'),
+                          INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"') - 1
+                         )
+              ) AS satisfies_value,
+              last_modified_at,
+              created_at
+          FROM CTE
+          WHERE extracted IS NOT NULL AND INSTR(LOWER(extracted), 'satisfies="') > 0
+      ),
+      SplitSatisfies AS (
+          SELECT
+              uniform_resource_id,
+              uri,
+              nature,
+              device_id,
+              content_digest,
+              title,
+              content,
+              extracted,
+              
+              TRIM(SUBSTR(satisfies_value, 1, INSTR(satisfies_value || ',', ',') - 1)) AS satisfy,
+              CASE
+                  WHEN INSTR(satisfies_value, ',') > 0 THEN
+                      TRIM(SUBSTR(satisfies_value, INSTR(satisfies_value, ',') + 1))
+                  ELSE
+                      NULL
+              END AS remaining_satisfies,
+              last_modified_at,
+              created_at
+          FROM ExtractSatisfies
+          WHERE satisfies_value IS NOT NULL AND satisfies_value != ''
+          UNION ALL
+          SELECT
+              uniform_resource_id,
+              uri,
+              nature,
+              device_id,
+              content_digest,
+              title,
+              content,
+              extracted,
+              TRIM(SUBSTR(remaining_satisfies, 1, INSTR(remaining_satisfies || ',', ',') - 1)) AS satisfy,
+              CASE
+                  WHEN INSTR(remaining_satisfies, ',') > 0 THEN
+                      TRIM(SUBSTR(remaining_satisfies, INSTR(remaining_satisfies, ',') + 1))
+                  ELSE
+                      NULL
+              END AS remaining_satisfies,
+              last_modified_at,
+              created_at
+          FROM SplitSatisfies
+          WHERE remaining_satisfies IS NOT NULL AND remaining_satisfies != ''
+      ),
+      latest_entries AS (
+            SELECT
+              uri,
+              MAX(last_modified_at) AS latest_last_modified_at
+            FROM
+              uniform_resource
+            GROUP BY
+              uri
+        )
+      SELECT
+          ss.uniform_resource_id,
+          ss.uri,
+          ss.nature,
+          ss.device_id,
+          ss.content_digest,
+          ss.title,
+          ss.content,
+          ss.extracted,
+          satisfy AS fii,
+          ss.last_modified_at,
+          ss.created_at,
+          ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title) AS row_num,
+     uniform_resource_id || '-' || hex(substr(title, 1, 50))|| '-0004-' || printf('%04d', ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title)) AS evidence_id    
+      FROM SplitSatisfies ss
+      JOIN 
+ latest_entries le
+        ON
+          ss.uri = le.uri AND ss.last_modified_at = le.latest_last_modified_at
+      WHERE satisfy IS NOT NULL AND satisfy != ''
+      group BY fii,ss.title order by ss.title;
+
+
+DROP VIEW IF EXISTS evidence_anchortag;
+CREATE VIEW evidence_anchortag AS WITH RECURSIVE CTE AS (
+    SELECT 
+        frontmatter->>'title' AS title,
+        uri,
+        nature,
+         device_id,
+         content_digest,
+        content,
+        INSTR(content, '<a') AS href_start,
+        INSTR(content, '</a>') AS href_end,
+        SUBSTR(content, INSTR(content, '<a'), 
+               INSTR(content, '</a>') - INSTR(content, '<a') + LENGTH('</a>')) AS extracted,
+        SUBSTR(content, INSTR(content, '</a>') + LENGTH('</a>')) AS remaining_content,
+        last_modified_at,
+        created_at,
+        uniform_resource_id
+    FROM
+        uniform_resource
+    WHERE
+        INSTR(content, '<a') > 0  AND (nature='mdx' OR nature='md')
+    UNION ALL
+    SELECT
+        title,
+        uri,
+        nature,
+        device_id,
+        content_digest,
+        content,
+        INSTR(remaining_content, '<a') AS href_start,
+        INSTR(remaining_content, '</a>') AS href_end,
+        SUBSTR(remaining_content, INSTR(remaining_content, '<a'), 
+               INSTR(remaining_content, '</a>') - INSTR(remaining_content, '<a') + LENGTH('</a>')) AS extracted,
+        SUBSTR(remaining_content, INSTR(remaining_content, '</a>') + LENGTH('</a>')) AS remaining_content,
+         last_modified_at,
+         created_at,
+         uniform_resource_id
+    FROM
+        CTE
+    WHERE
+        INSTR(remaining_content, '<a') > 0 AND INSTR(remaining_content, '</a>') > INSTR(remaining_content, '<a')
+  ),
+  satisfies_split AS (
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          SUBSTR(
+              extracted,
+              INSTR(extracted, 'satisfies="') + LENGTH('satisfies="'),
+              CASE
+                  WHEN INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') > 0 THEN
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') - 1
+                  ELSE
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"') - 1
+              END
+          ) AS satisfies,
+          SUBSTR(
+              extracted,
+              INSTR(extracted, 'satisfies="') + LENGTH('satisfies="') + CASE
+                  WHEN INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',') > 0 THEN
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), ',')
+                  ELSE
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"')
+              END + 1
+          ) AS rest_satisfies
+      FROM
+          CTE
+      WHERE
+          INSTR(extracted, 'satisfies="') > 0
+      UNION ALL
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          TRIM(SUBSTR(rest_satisfies, 1, INSTR(rest_satisfies, ',') - 1)) AS satisfies,
+          SUBSTR(rest_satisfies, INSTR(rest_satisfies, ',') + 1) AS rest_satisfies
+      FROM
+          satisfies_split
+      WHERE
+          INSTR(rest_satisfies, ',') > 0
+      UNION ALL
+      SELECT 
+          title,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          content,
+          extracted,
+          last_modified_at,
+          created_at,
+          uniform_resource_id,
+          TRIM(rest_satisfies) AS satisfies,
+          NULL AS rest_satisfies
+      FROM
+          satisfies_split
+      WHERE
+          INSTR(rest_satisfies, ',') = 0 AND LENGTH(TRIM(rest_satisfies)) > 0
+  ),
+  latest_entries AS (
+              SELECT
+                uri,
+                MAX(last_modified_at) AS latest_last_modified_at
+              FROM
+                uniform_resource
+              GROUP BY
+                uri
+          )
+  SELECT 
+  ss.uniform_resource_id,
+  ss.uri,
+  ss.nature,
+  ss.device_id,
+  ss.content_digest,
+      ss.title,
+      ss.content,
+      ss.extracted,
+      CASE
+          WHEN INSTR(satisfies, '"') > 0 THEN SUBSTR(satisfies, 1, INSTR(satisfies, '"') - 1)
+          ELSE satisfies
+      END AS fii,
+      ss.last_modified_at,
+      ss.created_at,
+      ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title) AS row_num,
+      uniform_resource_id || '-' || hex(substr(title, 1, 50))|| '-0002-' || printf('%04d', ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title)) AS evidence_id
+  FROM
+      satisfies_split ss
+      JOIN 
+  latest_entries le
+          ON
+            ss.uri = le.uri AND ss.last_modified_at = le.latest_last_modified_at
+  WHERE
+      satisfies IS NOT NULL AND satisfies != '' AND fii LIKE '%FII%' 
+  group by ss.title,fii
+  ORDER BY
+      ss.title, fii;
+
+
+DROP VIEW IF EXISTS evidence_imagetag;
+CREATE VIEW evidence_imagetag AS
+  WITH RECURSIVE CTE AS (
+      -- Base case: Initial extraction
+      SELECT
+          uniform_resource_id,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          frontmatter->>'title' AS title,
+          content,
+          INSTR(content, '<img') AS imgtag_start,
+          INSTR(SUBSTR(content, INSTR(content, '<img')), '/>') AS imgtag_end,
+          SUBSTR(content, INSTR(content, '<img'), INSTR(SUBSTR(content, INSTR(content, '<img')), '/>') + 1) AS extracted,
+          SUBSTR(content, INSTR(content, '<img') + INSTR(SUBSTR(content, INSTR(content, '<img')), '/>') + 1) AS remaining_content ,
+          last_modified_at,
+          created_at
+      FROM uniform_resource 
+      WHERE INSTR(content, '<img') > 0
+      UNION ALL
+      SELECT
+          uniform_resource_id,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          title,
+          content,
+          INSTR(remaining_content, '<img') AS imgtag_start,
+          INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<img')), '/>') AS imgtag_end,
+          SUBSTR(remaining_content, INSTR(remaining_content, '<img'), INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<img')), '/>') + 1) AS extracted,
+          SUBSTR(remaining_content, INSTR(remaining_content, '<img') + INSTR(SUBSTR(remaining_content, INSTR(remaining_content, '<img')), '/>') + 1) AS remaining_content,
+          last_modified_at,
+          created_at
+      FROM CTE
+      WHERE INSTR(remaining_content, '<img') > 0
+  ),
+  ExtractSatisfies AS (
+      SELECT
+          uniform_resource_id,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          title,
+          content,
+          extracted,
+          
+          -- Extract the value of the satisfies attribute
+          TRIM(SUBSTR(extracted,
+                      INSTR(extracted, 'satisfies="') + LENGTH('satisfies="'),
+                      INSTR(SUBSTR(extracted, INSTR(extracted, 'satisfies="') + LENGTH('satisfies="')), '"') - 1
+                    )
+          ) AS satisfies_value,
+          last_modified_at,
+          created_at
+      FROM CTE
+      WHERE extracted IS NOT NULL AND INSTR(LOWER(extracted), 'satisfies="') > 0
+  ),
+  SplitSatisfies AS (
+      SELECT
+          uniform_resource_id,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          title,
+          content,
+          extracted,
+          
+          TRIM(SUBSTR(satisfies_value, 1, INSTR(satisfies_value || ',', ',') - 1)) AS satisfy,
+          CASE
+              WHEN INSTR(satisfies_value, ',') > 0 THEN
+                  TRIM(SUBSTR(satisfies_value, INSTR(satisfies_value, ',') + 1))
+              ELSE
+                  NULL
+          END AS remaining_satisfies,
+          last_modified_at,
+          created_at
+      FROM ExtractSatisfies
+      WHERE satisfies_value IS NOT NULL AND satisfies_value != ''
+      UNION ALL
+      SELECT
+          uniform_resource_id,
+          uri,
+          nature,
+          device_id,
+          content_digest,
+          title,
+          content,
+          extracted,
+          TRIM(SUBSTR(remaining_satisfies, 1, INSTR(remaining_satisfies || ',', ',') - 1)) AS satisfy,
+          CASE
+              WHEN INSTR(remaining_satisfies, ',') > 0 THEN
+                  TRIM(SUBSTR(remaining_satisfies, INSTR(remaining_satisfies, ',') + 1))
+              ELSE
+                  NULL
+          END AS remaining_satisfies,
+          last_modified_at,
+          created_at
+      FROM SplitSatisfies
+      WHERE remaining_satisfies IS NOT NULL AND remaining_satisfies != ''
+  ),
+  latest_entries AS (
+              SELECT
+                uri,
+                MAX(last_modified_at) AS latest_last_modified_at
+              FROM
+                uniform_resource
+              GROUP BY
+                uri
+          )
+  SELECT
+      ss.uniform_resource_id,
+      ss.uri,
+      ss.nature,
+      ss.device_id,
+      ss.content_digest,
+      ss.title,
+      ss.content,
+      ss.extracted,
+      ss.satisfy AS fii,
+      ss.last_modified_at,
+      ss.created_at,
+      ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title) AS row_num,
+      uniform_resource_id || '-' || hex(substr(title, 1, 50))|| '-0003-' || printf('%04d', ROW_NUMBER() OVER (PARTITION BY uniform_resource_id, title ORDER BY uniform_resource_id, title)) AS evidence_id        
+  FROM SplitSatisfies ss
+  JOIN 
+  latest_entries le
+          ON
+            ss.uri = le.uri AND ss.last_modified_at = le.latest_last_modified_at
+  WHERE ss.satisfy IS NOT NULL AND ss.satisfy != ''
+  group by fii,ss.title order by ss.title;
+
+DROP VIEW IF EXISTS audit_session_control_status;
+CREATE VIEW audit_session_control_status AS 
       SELECT
       a.audit_session_id,
       a.title,
@@ -153,8 +1088,164 @@ CREATE VIEW IF NOT EXISTS audit_session_control_status AS
         a.audit_session_id 
       ORDER BY cg.display_order ASC;
 
+DROP VIEW IF EXISTS control_group;
+CREATE VIEW control_group AS 
+          SELECT
+              cast("#" as int)  as display_order,
+              ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='SOC2 Type I' AND parent_id!="") AS control_group_id,
+              "Common Criteria" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='SOC2 Type I' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM
+              uniform_resource_aicpa_soc2_controls
+            GROUP BY
+              "Common Criteria"
+              
+          UNION ALL
 
-CREATE VIEW IF NOT EXISTS control AS
+            SELECT
+            cast("#" as int)  as display_order,
+            ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+            (SELECT control_regime_id FROM control_regime WHERE name='SOC2 Type II' AND parent_id!="") AS control_group_id,
+            "Common Criteria" AS title,
+            (SELECT control_regime_id FROM control_regime WHERE name='SOC2 Type II' AND parent_id!="") AS audit_type_id,
+            NULL AS parent_id
+              FROM uniform_resource_aicpa_soc2_type2_controls
+            GROUP BY
+              "Common Criteria" 
+          
+          UNION ALL
+
+            SELECT
+            cast("#" as int)  as display_order,
+            ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+            (SELECT control_regime_id FROM control_regime WHERE name='HIPAA' AND parent_id!="") AS control_group_id,
+            "Common Criteria" AS title,
+            (SELECT control_regime_id FROM control_regime WHERE name='HIPAA' AND parent_id!="") AS audit_type_id,
+            NULL AS parent_id
+              FROM uniform_resource_hipaa_security_rule_safeguards
+            GROUP BY
+              "Common Criteria"
+
+          UNION ALL
+
+            SELECT
+            cast("#" as int)  as display_order,
+            ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+            (SELECT control_regime_id FROM control_regime WHERE name='HiTRUST e1 Assessment' AND parent_id!="") AS control_group_id,
+            "Common Criteria" AS title,
+            (SELECT control_regime_id FROM control_regime WHERE name='HiTRUST e1 Assessment' AND parent_id!="") AS audit_type_id,
+            NULL AS parent_id
+              FROM uniform_resource_hitrust_e1_assessment
+            GROUP BY
+              "Common Criteria" 
+
+          UNION ALL
+
+            SELECT
+              (SELECT COUNT(*)
+              FROM uniform_resource_scf_2024_2 AS sub
+              WHERE sub.ROWID <= cntl.ROWID AND sub."US CMMC 2.0 Level 1" != "") AS display_order,
+              ROW_NUMBER() OVER (ORDER BY cntl."SCF Domain")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 1' AND parent_id!="") AS control_group_id,
+              cntl."SCF Domain" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 1' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_scf_2024_2 cntl
+            WHERE
+              cntl."US CMMC 2.0 Level 1" != ""
+            GROUP BY
+              cntl."SCF Domain"
+
+          UNION ALL
+
+            SELECT
+              (SELECT COUNT(*)
+              FROM uniform_resource_scf_2024_2 AS sub
+              WHERE sub.ROWID <= cntl.ROWID AND sub."US CMMC 2.0 Level 2" != "") AS display_order,
+              ROW_NUMBER() OVER (ORDER BY cntl."SCF Domain")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 2' AND parent_id!="") AS control_group_id,
+              cntl."SCF Domain" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 2' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_scf_2024_2 cntl
+            WHERE
+              cntl."US CMMC 2.0 Level 2" != ""
+            GROUP BY
+              cntl."SCF Domain"
+
+          UNION ALL
+
+            SELECT
+              (SELECT COUNT(*)
+              FROM uniform_resource_scf_2024_2 AS sub
+              WHERE sub.ROWID <= cntl.ROWID AND sub."US CMMC 2.0 Level 3" != "") AS display_order,
+              ROW_NUMBER() OVER (ORDER BY "SCF Domain")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 3' AND parent_id!="") AS control_group_id,
+              cntl."SCF Domain" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='CMMC Model 2.0 LEVEL 3' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_scf_2024_2 cntl
+            WHERE
+              cntl."US CMMC 2.0 Level 3" != ""
+            GROUP BY
+              cntl."SCF Domain"
+            
+          UNION ALL
+
+            SELECT
+              cast("#" as int)  as display_order,
+              ROW_NUMBER() OVER (ORDER BY "SCF Domain")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='Together.Health Security Assessment (THSA)' AND parent_id!="") AS control_group_id,
+              "SCF Domain" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='Together.Health Security Assessment (THSA)' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_thsa
+            GROUP BY
+              "SCF Domain"
+          
+          UNION ALL
+
+            SELECT
+              cast("#" as int)  as display_order,
+              ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='Code Quality Infrastructure' AND parent_id!="") AS control_group_id,
+              "Common Criteria" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='Code Quality Infrastructure' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_code_quality_infrastructure
+            GROUP BY
+              "Common Criteria"
+
+          UNION ALL
+
+            SELECT
+              cast("#" as int)  as display_order,
+              ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='Database Quality Infrastructure' AND parent_id!="") AS control_group_id,
+              "Common Criteria" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='Database Quality Infrastructure' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_database_quality_infrastructure
+            GROUP BY
+              "Common Criteria"
+
+          UNION ALL
+
+            SELECT
+              cast("#" as int)  as display_order,
+              ROW_NUMBER() OVER (ORDER BY "Common Criteria")  || '-' ||
+              (SELECT control_regime_id FROM control_regime WHERE name='Scheduled Audit' AND parent_id!="") AS control_group_id,
+              "Common Criteria" AS title,
+              (SELECT control_regime_id FROM control_regime WHERE name='Scheduled Audit' AND parent_id!="") AS audit_type_id,
+              NULL AS parent_id
+            FROM  uniform_resource_scheduled_audit
+            GROUP BY
+              "Common Criteria";
+
+DROP VIEW IF EXISTS control;
+CREATE VIEW control AS
             WITH control_regime_cte AS (
               SELECT
                 reg.name as control_regime,
@@ -413,4 +1504,4 @@ CREATE VIEW IF NOT EXISTS control AS
         FROM uniform_resource_scheduled_audit cntl
         INNER JOIN control_group cg ON cg.title=cntl."Common Criteria"
         WHERE cg.audit_type_id=(SELECT audit_type_id FROM control_regime_cte WHERE audit_type_name='Scheduled Audit');
-      
+

--- a/pattern/infra-audit/ux.sql.ts
+++ b/pattern/infra-audit/ux.sql.ts
@@ -46,7 +46,12 @@ export class InfraAuditSqlPages extends spn.TypicalSqlPageNotebook {
 
   @iaNav({
     caption: "Infrastructure Audits",
-    description: "Infrastructure Audits",
+    description:
+      `The Infra Audit is designed to manage and streamline audits across
+various frameworks, including HIPAA, HITRUST, AICPA, and others. This project
+provides a comprehensive platform for conducting, tracking, and reporting on
+compliance audits, ensuring that your organization meets the necessary
+regulatory requirements.`,
     siblingOrder: 2,
   })
   "opsfolio/infra/audit/index.sql"() {
@@ -89,7 +94,7 @@ export class InfraAuditSqlPages extends spn.TypicalSqlPageNotebook {
            TRUE AS search,
            'Session' AS markdown;
 
-    SELECT '[' || title || '](/infra/audit/session_detail.sql?id=' || audit_type_id  || '&sessionid=' || audit_session_id || ')' AS "Session",
+    SELECT '[' || title || '](/opsfolio/infra/audit/session_detail.sql?id=' || audit_type_id  || '&sessionid=' || audit_session_id || ')' AS "Session",
            audit_type AS "Audit Type",
            due_date AS "Due Date",
            tenant_name AS "Tenant"
@@ -111,7 +116,7 @@ export class InfraAuditSqlPages extends spn.TypicalSqlPageNotebook {
     select 'table' as component,
     'Control code' AS markdown;
     SELECT
-    '[' || control_code || '](/infra/audit/control_detail.sql?id=' || control_id || ')' AS "Control code",
+    '[' || control_code || '](/opsfolio/infra/audit/control_detail.sql?id=' || control_id || ')' AS "Control code",
     common_criteria as "Common criteria",
     question as "Question"
       FROM control WHERE CAST(audit_type_id AS TEXT)=CAST($id AS TEXT);
@@ -125,10 +130,17 @@ export class InfraAuditSqlPages extends spn.TypicalSqlPageNotebook {
   })
   "opsfolio/infra/audit/control_detail.sql"() {
     return this.SQL`
-    SELECT 'card' as component
-    SELECT question  as title, common_criteria
-      FROM control WHERE CAST(control_id AS TEXT)=CAST($id AS TEXT);
-    `;
+    SELECT
+      'title' AS component
+      select 'table' as component
+      SELECT
+      fii AS "FII",
+      question AS "Question",
+      common_criteria as "Common criteria",
+      expected_evidence as "Evidence",
+      control_regime as "Control Regime"
+        FROM control WHERE CAST(control_id AS TEXT)=CAST($id AS TEXT);
+      `;
   }
 }
 
@@ -154,27 +166,6 @@ export async function auditSQL() {
     new c.ConsoleSqlPages(),
     new ur.UniformResourceSqlPages(),
     new orch.OrchestrationSqlPages(),
-    new InfraAuditSqlPages(),
-  );
-}
-
-export async function opsfolioAuditSQL() {
-  return await spn.TypicalSqlPageNotebook.SQL(
-    new class extends spn.TypicalSqlPageNotebook {
-      async statelessAuditSQL() {
-        // read the file from either local or remote (depending on location of this file)
-        return await spn.TypicalSqlPageNotebook.fetchText(
-          import.meta.resolve("./stateless-ia.surveilr.sql"),
-        );
-      }
-
-      async orchestrateStatefulIaSQL() {
-        // read the file from either local or remote (depending on location of this file)
-        // return await spn.TypicalSqlPageNotebook.fetchText(
-        //   import.meta.resolve("./stateful-drh-surveilr.sql"),
-        // );
-      }
-    }(),
     new InfraAuditSqlPages(),
   );
 }

--- a/service/opsfolio/web-ui.sql.ts
+++ b/service/opsfolio/web-ui.sql.ts
@@ -1,6 +1,7 @@
 import * as control from "../../pattern/info-assurance-controls/ux.sql.ts";
 import * as policy from "../../pattern/info-assurance-policies/ux.sql.ts";
 import * as infraAssurance from "../../pattern/infra-assurance/ux.sql.ts";
+import * as infraAudit from "../../pattern/infra-audit/ux.sql.ts";
 
 if (import.meta.main) console.log((await SQL()).join("\n"));
 
@@ -9,6 +10,7 @@ export async function SQL() {
     ...(await control.controlSQL()),
     ...(await policy.policySQL()),
     ...(await infraAssurance.assuranceSQL()),
+    ...(await infraAudit.auditSQL()),
   ];
 }
 


### PR DESCRIPTION
This pull request enhances the unified SQL view by integrating infra audit controls. The changes involve the following:

- Imported infra-audit module from ../../pattern/infra-audit/ux.sql.ts to include infra audit-related SQL queries in the unified view.

- Updated the SQL() function to include SQL statements from infraAudit.auditSQL() in the returned array.

- Modified the import section to ensure all relevant modules (control, policy, infraAssurance, infraAudit) are imported correctly.

- Adjusted the output to log the consolidated SQL statements when run in the main context