### PR TITLE
fix: duplicate breadcrumb #30

### DIFF
--- a/prime/web-ui-content/console.ts
+++ b/prime/web-ui-content/console.ts
@@ -120,6 +120,7 @@ export class ConsoleSqlPages extends spn.TypicalSqlPageNotebook {
           CONSTRAINT unq_ns_path UNIQUE (namespace, parent_path, path)
       );
       DELETE FROM sqlpage_aide_navigation WHERE path LIKE '/console/%';
+      DELETE FROM sqlpage_aide_navigation WHERE path LIKE '/%';
 
       -- all @navigation decorated entries are automatically added to this.navigation
       ${this.upsertNavSQL(...Array.from(this.navigation.values()))}


### PR DESCRIPTION
This PR addresses the issue where running the watch command (../../support/bin/sqlpagectl.ts dev --watch . --watch ../../prime) results in unintended entries being created in the sqlpage_aide_navigation table, specifically an entry labeled "Home" that displays in the breadcrumb. The changes ensure the table remains idempotent by clearing existing paths before repopulating it

**Idempotency Improvement:**

- Added a DELETE statement to clear the table before repopulating it:

`DELETE FROM sqlpage_aide_navigation WHERE path LIKE '/%';`

- This ensures that any previously created paths (including unintended "Home" entries) are removed, preventing duplicate or stale entries in the table.